### PR TITLE
fix dockerfile and listen on all network interfaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,5 +47,4 @@ RUN cp target/$(cat /opt/.cargo-target)/release/preview_bot .
 # == Bundle Stage ==
 FROM scratch
 COPY --from=builder /opt/previewbot/preview_bot /
-CMD [ "./preview_bot" ]
-
+ENTRYPOINT [ "./preview_bot" ]

--- a/src/web/serve.rs
+++ b/src/web/serve.rs
@@ -37,7 +37,7 @@ pub(crate) async fn serve_unix_listener(app: Router, socket_path_string: &str) {
 
 pub(crate) async fn serve_tcp_listener(app: Router, port_string: &str) {
     let port: u16 = port_string.parse().expect("PORT is not a valid number.");
-    let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port);
+    let addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), port);
     let listener = TcpListener::bind(&addr).await.unwrap();
 
     println!("Running server on TCP port {port}...");


### PR DESCRIPTION
- listen on `0.0.0.0` (i.e. ALL network interfaces) instead of `localhost` only
- use `ENTRYPOINT` instead of `CMD` in the dockerfile so that adding parameters like ex. `--reload-commands` at runtime does not require repeating the binary name (`./preview_bot`)